### PR TITLE
Math - convertAngle

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ once. For example `isPromise` is exported from both the `promise` and the
     - [transformCase](#transformcase)
 - __`math`__
     - [clamp](#clamp)
+    - [convertAngle](#convertangle)
 - __`data structures`__
     - [BiMap](#bimap)
     - [SortedArray](#sortedarray)
@@ -1764,6 +1765,36 @@ camel('foo_bar') // 'fooBar'
 
 
 
+
+---
+
+#### `convertAngle` 
+  
+```hs
+(value: number, from: Angle, to: Angle) => number
+```
+
+<sup><sup>_[source](https://github.com/MathisBullinger/froebel/blob/main/convertAngle.ts#L13)_ | _[tests](https://github.com/MathisBullinger/froebel/blob/main/convertAngle.test.ts)_</sup></sup>
+
+> Converts angle values from one unit to another.
+> Supported units: degrees, radians
+
+
+#### Import
+
+```ts
+/* Node: */  import convertAngle from "froebel/convertAngle";
+/* Deno: */  import convertAngle from "https://deno.land/x/froebel@v0.16.1/convertAngle.ts";
+```
+
+
+
+
+#### Example
+```ts
+convertAngle(180, "degree", "radian") // 3.141592653589793
+convertAngle(MAth.PI, "radian", "degree") // 180
+```
 ## Data Structures
 
 #### `BiMap` 

--- a/convertAngle.test.ts
+++ b/convertAngle.test.ts
@@ -1,0 +1,19 @@
+import convertAngle from "./convertAngle.ts";
+import { assertEquals, assertThrows } from "testing/asserts.ts";
+
+Deno.test("convertAngle", () => {
+  assertEquals(convertAngle(123, "degree", "degree"), 123);
+  assertEquals(convertAngle(123, "radian", "radian"), 123);
+  assertThrows(() => convertAngle(123, "invalidUnit", "invalidUnit"), 123);
+
+  assertEquals(convertAngle(0, "degree", "radian"), 0);
+  assertEquals(convertAngle(0, "radian", "degree"), 0);
+
+  assertEquals(convertAngle(180, "degree", "radian"), Math.PI);
+  assertEquals(convertAngle(360, "degree", "radian"), Math.PI * 2);
+  assertEquals(convertAngle(Math.PI, "radian", "degree"), 180);
+  assertEquals(convertAngle(Math.PI * 2, "radian", "degree"), 360);
+  
+  assertThrows(() => convertAngle(0, "invalidUnit", "radian"), TypeError);
+  assertThrows(() => convertAngle(0, "degree", "invalidUnit"), TypeError);
+});

--- a/convertAngle.test.ts
+++ b/convertAngle.test.ts
@@ -1,10 +1,9 @@
 import convertAngle from "./convertAngle.ts";
-import { assertEquals, assertThrows } from "testing/asserts.ts";
+import { AssertionError, assertEquals, assertThrows } from "testing/asserts.ts";
 
 Deno.test("convertAngle", () => {
   assertEquals(convertAngle(123, "degree", "degree"), 123);
   assertEquals(convertAngle(123, "radian", "radian"), 123);
-  assertThrows(() => convertAngle(123, "invalidUnit", "invalidUnit"), 123);
 
   assertEquals(convertAngle(0, "degree", "radian"), 0);
   assertEquals(convertAngle(0, "radian", "degree"), 0);
@@ -13,7 +12,9 @@ Deno.test("convertAngle", () => {
   assertEquals(convertAngle(360, "degree", "radian"), Math.PI * 2);
   assertEquals(convertAngle(Math.PI, "radian", "degree"), 180);
   assertEquals(convertAngle(Math.PI * 2, "radian", "degree"), 360);
-  
-  assertThrows(() => convertAngle(0, "invalidUnit", "radian"), TypeError);
-  assertThrows(() => convertAngle(0, "degree", "invalidUnit"), TypeError);
+
+  // @ts-ignore
+  assertThrows(() => convertAngle(0, "invalidUnit", "radian"), AssertionError);
+  // @ts-ignore
+  assertThrows(() => convertAngle(0, "degree", "invalidUnit"), AssertionError);
 });

--- a/convertAngle.test.ts
+++ b/convertAngle.test.ts
@@ -1,5 +1,5 @@
 import convertAngle from "./convertAngle.ts";
-import { AssertionError, assertEquals, assertThrows } from "testing/asserts.ts";
+import { assertEquals, assertThrows } from "testing/asserts.ts";
 
 Deno.test("convertAngle", () => {
   assertEquals(convertAngle(123, "degree", "degree"), 123);
@@ -14,7 +14,7 @@ Deno.test("convertAngle", () => {
   assertEquals(convertAngle(Math.PI * 2, "radian", "degree"), 360);
 
   // @ts-ignore
-  assertThrows(() => convertAngle(0, "invalidUnit", "radian"), AssertionError);
+  assertThrows(() => convertAngle(0, "invalidUnit", "radian"), TypeError);
   // @ts-ignore
-  assertThrows(() => convertAngle(0, "degree", "invalidUnit"), AssertionError);
+  assertThrows(() => convertAngle(0, "degree", "invalidUnit"), TypeError);
 });

--- a/convertAngle.ts
+++ b/convertAngle.ts
@@ -1,3 +1,7 @@
+import { assert } from "testing/asserts.ts";
+import oneOf from "./oneOf.ts";
+
+
 type Angle = "degree" | "radian";
 
 /**
@@ -11,6 +15,15 @@ type Angle = "degree" | "radian";
  * ```
  */
 const convertAngle = (value: number, from: Angle, to: Angle): number => {
+  assert(
+    oneOf(from, "degree", "radian"),
+    `convertAngle: unknown unit ${from}`,
+  );
+  assert(
+    oneOf(to, "degree", "radian"),
+    `convertAngle: unknown unit ${to}`,
+  );
+
   if (from === to) {
     return value;
   }
@@ -23,9 +36,6 @@ const convertAngle = (value: number, from: Angle, to: Angle): number => {
 
     case "radian":
       return degree * Math.PI / 180;
-
-    default:
-      throw TypeError(`convertAngle: unknown unit ${to}`);
   }
 };
 
@@ -36,9 +46,6 @@ const toDegree = (value: number, unit: Angle): number => {
 
     case "radian":
       return value * 180 / Math.PI;
-
-    default:
-      throw TypeError(`convertAngle: unknown unit ${unit}`);
   }
 };
 

--- a/convertAngle.ts
+++ b/convertAngle.ts
@@ -1,7 +1,6 @@
 import { assert } from "./except.ts";
 import oneOf from "./oneOf.ts";
 
-
 type Angle = "degree" | "radian";
 
 /**

--- a/convertAngle.ts
+++ b/convertAngle.ts
@@ -1,0 +1,45 @@
+type Angle = "degree" | "radian";
+
+/**
+ * Converts angle values from one unit to another.
+ * Supported units: degrees, radians
+ *
+ * @example
+ * ```
+ * convertAngle(180, "degree", "radian") // 3.141592653589793
+ * convertAngle(MAth.PI, "radian", "degree") // 180
+ * ```
+ */
+const convertAngle = (value: number, from: Angle, to: Angle): number => {
+  if (from === to) {
+    return value;
+  }
+
+  const degree = toDegree(value, from);
+
+  switch (to) {
+    case "degree":
+      return degree;
+
+    case "radian":
+      return degree * Math.PI / 180;
+
+    default:
+      throw TypeError(`convertAngle: unknown unit ${to}`);
+  }
+};
+
+const toDegree = (value: number, unit: Angle): number => {
+  switch (unit) {
+    case "degree":
+      return value;
+
+    case "radian":
+      return value * 180 / Math.PI;
+
+    default:
+      throw TypeError(`convertAngle: unknown unit ${unit}`);
+  }
+};
+
+export default convertAngle;

--- a/convertAngle.ts
+++ b/convertAngle.ts
@@ -1,4 +1,4 @@
-import { assert } from "testing/asserts.ts";
+import { assert } from "./except.ts";
 import oneOf from "./oneOf.ts";
 
 
@@ -18,10 +18,12 @@ const convertAngle = (value: number, from: Angle, to: Angle): number => {
   assert(
     oneOf(from, "degree", "radian"),
     `convertAngle: unknown unit ${from}`,
+    TypeError,
   );
   assert(
     oneOf(to, "degree", "radian"),
     `convertAngle: unknown unit ${to}`,
+    TypeError,
   );
 
   if (from === to) {

--- a/math.ts
+++ b/math.ts
@@ -1,1 +1,2 @@
 export { default as clamp } from "./clamp.ts";
+export { default as convertAngle } from "./convertAngle.ts";


### PR DESCRIPTION
This time I used the deno script to generate the readme doc.

I added
```
if (from === to) {
  return value;
}
```
because with the double conversion, something like `convertAngle(18, 'radian', 'radian')` returned `18.000000000000004`.

Let me know if you see something you'd like to do differently.