### PR TITLE
chore: use dependabot to update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Changes:

- Use Dependabot [^dependabot] to update your GitHub Action runners

## Context:

You're using an old version of the `actions/checkout` runner in this file, the newest version is `v3`:

https://github.com/MathisBullinger/froebel/blob/adcb8a276235d32c45c738cb26eb696abc46247b/.github/workflows/test.yml#L10

To fix this you can:

- manually bump the version,
- or let a bot create update pull requests that you review and merge

I think using a bot is better, as the bot won't forget. 😉

Dependabot is built-in to GitHub, so you don't need to install anything.

## What will happen after you merge this PR

1. Dependabot will run right away and check for GitHub Action updates
2. After that Dependabot will run as set in the `schedule.interval`

## Scheduling

You can choose when Dependabot checks for updates with the `schedule.interval` [^interval] option:

-  `daily` <-- Once a day on Monday through Friday
-  `weekly` <-- Once per week, default on Monday
-  `monthly` <-- Once a month, first day of the month

[^dependabot]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates
[^interval]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval