### PR TITLE
fix: Use correct function in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1878,7 +1878,7 @@ snake('fooBar') // 'foo_bar'
 
 #### Example
 ```ts
-snake('fooBar') // 'foo-bar'
+kebab('fooBar') // 'foo-bar'
 ```
 
 ---


### PR DESCRIPTION
In the [kebab](https://github.com/MathisBullinger/froebel#kebab) case function example, `snake` is used instead. To demonstrate the issue:
```sh
~ $ deno
> import { kebab, snake } from "https://deno.land/x/froebel@v0.20.0/case.ts";
undefined
> snake('fooBar')
"foo_bar"
> kebab('fooBar')
"foo-bar"
```

The actual example uses `snake` but outputs `kebab`:
<img width="261" alt="image" src="https://user-images.githubusercontent.com/7507990/183438394-21a3ba03-0fe7-476e-91dd-f76e7da8e3ab.png">

This PR addresses the inconsistency.